### PR TITLE
Added playlist_id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Command line usage:
 Extra command line options:
   -p, --playlist       Downloads a saved playlist from your account
   -ls, --liked-songs   Downloads all the liked songs from your account
+  -pid, --playlist-id [id] [folder_name]  Downloads a playlist from their id and saves in folder_name. This playlist can be created by other user, not only your playlists. 
 
 Special hardcoded options:
   ROOT_PATH           Change this path if you don't like the default directory where ZSpotify saves the music
@@ -54,6 +55,9 @@ Special hardcoded options:
 
 
 ## **Changelog:**
+
+**v1.9.1 (19 Aug 2022)**
+- Added extra option to download a playlist with the playlist-id. This playlist doesn't need be yours, it can be from other user.
 
 **v1.9 (20 Jun 2022):**
 - Fix fails at 87%

--- a/zspotify.py
+++ b/zspotify.py
@@ -137,6 +137,11 @@ def client():
     if len(sys.argv) > 1:
         if sys.argv[1] == "-p" or sys.argv[1] == "--playlist":
             download_from_user_playlist()
+        elif sys.argv[1] == "-pid" or sys.argv[1] == "--playlist_id":
+            if len(sys.argv) > 3:
+                download_playlist_by_id(sys.argv[2], sys.argv[3])
+            else:
+                print("With the flag playlist_id you must pass the playlist_id and the name of the folder where you will have the songs. Usually these name is the name of the playlist itself.")
         elif sys.argv[1] == "-ls" or sys.argv[1] == "--liked-songs":
             for song in get_saved_tracks(token):
                 if not song['track']['name']:
@@ -842,6 +847,16 @@ def download_playlist(playlists, playlist_choice):
                 playlists[int(playlist_choice) - 1]['name'].strip()) + "/")
         print("\n")
 
+def download_playlist_by_id(playlist_id, playlist_name):
+    """Downloads all the songs from a playlist using playlist id"""
+    token = SESSION.tokens().get("user-read-email")
+
+    playlist_songs = get_playlist_songs(token, playlist_id)
+
+    for song in playlist_songs:
+        if song['track']['id'] is not None:
+            download_track(song['track']['id'], sanitize_data(playlist_name.strip()) + "/")
+        print("\n")
 
 def download_from_user_playlist():
     """ Select which playlist(s) to download """


### PR DESCRIPTION
A command extra option in order to download a playlist from their id was added. 

Basically I added the extra option in the client menu and cloned the download_playlist function bypassing the process of obtaing the playlist_id from the option selected by the user. Using direclty the playlist_id we can download public playlists from other users, not only ours playlists.

This extra option needs two parameters: playlist_id and the name of the folder that the script use to save the songs. To avoid a query about the playlist I passed directly the name of the folder.

Thank you for your attention!