### PR TITLE
fix id3 date tag by giving option to use mutagen directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/kokarare1212/librespot-python
+mutagen
 music_tag
 pydub
 Pillow


### PR DESCRIPTION
[Fixes #34](https://github.com/jsavargas/zspotify/issues/34#issue-1409780833) and #20 
Where music_tag module incorrectly sets "Year" ID3 frame. As the module is a layer for mutagen, I made a function that uses mutagen directly.
Two date frames are tagged with the existing tag, and correct tag to insure supporting viewers/players/clients can read the year.
Also Album Artist (TPE2) is now set. The artist is used unless it's a compilation, then "Various Artists" is used. Various Artists is required in the TPE2 for some music organizing platforms (Plex) to sort Albums correctly.
Album art is embedded in this function as well, so the music_tag module can be completely dropped.

You can revert back to the music_tag method by changing
USE_MUTAGEN = True to USE_MUTAGEN = False, as the old functions are still present.

I've put a bunch of time trying various methods. I even explored setting tags and album art with pydub as ffmpeg does all the encoding and is a dep anyhow. Ffmpeg was able to set all meta and album art with the exception of the COMM (Comment) frame.  That was a show stopper :(

Once again... I now have under 2 weeks total Python experience, and have yet to take a tutorial. Feel free to edit or toss the pull request out.

Cheers!

Edit: 
`#tags['TCON'] = TCON(encoding=3, text=genre)              # TCON Genre - TODO`
Is new, but commented out to be used in the future.  It is working on my copy of Zspotify, but would require a bunch of tweaks to get it working on "Vanilla" Zspotify.