### PR TITLE
Meta tagging, conversion improvements. Podcast conversion, tagging and download checks.

### DIFF
--- a/zspotify.py
+++ b/zspotify.py
@@ -380,7 +380,7 @@ def download_episode(episode_id_str):
     check_all_time = episode_id_str in get_previously_downloaded()
     episode_filename = f'{podcast_name}-{episode_name}.{MUSIC_FORMAT}'
     filename = os.path.join(ROOT_PODCAST_PATH, podcast_name, episode_filename)
-    tempfile = os.path.join(ROOT_PODCAST_PATH, podcast_name, "raw.tmp")
+    tempfile = os.path.join(ROOT_PODCAST_PATH, podcast_name, episode_filename[:-4] + "-vorbis.raw")
  
     if podcast_name is None:
         print("###   SKIPPING: (EPISODE NOT FOUND)   ###")
@@ -929,7 +929,7 @@ def download_track(track_id_str: str, extra_paths="", prefix=False, prefix_value
             song_name = f'{_artist} - {name}.{MUSIC_FORMAT}'
             filename = os.path.join(ROOT_PATH, extra_paths, song_name)
         check_all_time = scraped_song_id in get_previously_downloaded()
-        tempfile = os.path.join(ROOT_PATH, extra_paths, "raw.tmp")
+        tempfile = os.path.join(ROOT_PATH, extra_paths, song_name[:-4] + "-vorbis.raw")
 
     except Exception as e:
         print("###   SKIPPING SONG - FAILED TO QUERY METADATA   ###")


### PR DESCRIPTION
Adds improvements and fixes several issues. Some not reported.
I'll supply the details and findings soon. Time is limited at the moment.

Please note, this pull request is for the PR branch!

Edit: Details below.

Several things have been fixed or added. I would like to of added these changes gradually,but I didn't know how to do it without breaking things as it involved touching too many functions.

### Added ogg tagging to mutagen method of tagging and albumart embedding.
- Tagging ogg and embedding art is completely different than mp3. This now works when USE_MUTAGEN = True

  
### Added SKIP_EXISTING_FILES, SKIP_PREVIOUSLY_DOWNLOADED, RAW_AUDIO_AS_IS checks to podcast downloads.

- This has never been added. Fixes #48

  
### Added encoding and tagging of podcast files.

- largest (podcast) album image size code borrowed from @NightCorpse.
- Mentioned in #48

  
### Option to use ffmpeg-python rather than pydub, for dramatic performance increase (USE_FFMPEG).

- pydub is awesome. But overkill for our needs. All audio segments are encoded to .wav format. Then encoded to ogg or mp3. So lossy raw Vorbis is converted to lossless .wav, then lossy converted to ogg or mp3. Wasted time and quality. pydub  is a ffmpeg wrapper. Ffmpeg does all the heavy lifting in the background. ffmpeg-python is also a ffmpeg wrapper. But converts raw Vorbis to mp3 in one go. If ogg, raw Vorbis stream is copied untouched into a proper ogg container needed for tagging. It happens in a flash.
- convert_audio_format() has been modified to use either method.

  
### Artist genres are collected from Spotify artist data and are now tagged in ogg and mp3 files (USE_MUTAGEN).

- Every song will require one query to the API to discover the genre(s). A artist/genre cache per session is planned as downloading whole albums or playlists with the same artists will result in wasted API queries.
- Multiple genres are written comma seperated in genre meta tag.

### Raw Vorbis data for podcast was saved incorrectly as .wav

- Fixes #52
- Many music players will play the file, but some will not. Now saved as mp3 or ogg in proper containers with headers.
- RAW_AUDIO_AS_IS is possible.  Although Vorbis encoded data does not seem to have a documented file extension. It is meant to be in a container. For now it is saved as filename.tmp. Users that know what to do with the raw data should have no trouble  renaming the files to whatever suits them.

  
Performance increase is dramatic and obvious when processing podcast files as they are huge in comparison with song tracks. With pydub, ram usage  is through the roof, swap usage is not uncommon. Converting raw to wav, then to desired format is not needed and expensive. Creating ogg with USE_FFMPEG is nearly instant after download completes. Encoding to mp3 without converting to wav first is faster naturally.