### PR TITLE
add egg name for librespot-python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/kokarare1212/librespot-python
+git+https://github.com/kokarare1212/librespot-python#egg=librespot
 mutagen
 music_tag
 pydub


### PR DESCRIPTION
Extremely small PR that adds the egg name to the github url in requirements.txt for librespot-python. This helps some package managers such as pipenv that will otherwise throw an error.