### PR TITLE
Fixed recursive disc numbering in folder names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zspotify"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
     {"name" = "Jonathan Salinas Vargas"},
     {"name" = "Yuriy Kovrigin"},

--- a/zspotify/__main__.py
+++ b/zspotify/__main__.py
@@ -639,11 +639,12 @@ class ZSpotify:
 
         for song in songs:
             # Append disc number to filepath if more than 1 disc
+            newBasePath = basepath
             if disc_number_flag:
                 disc_number = self.sanitize_data(f"{self.zfill(song['disc_number'])}")
-                basepath = basepath / disc_number
+                newBasePath = basepath / disc_number
 
-            self.download_track(song['id'], basepath, "album")
+            self.download_track(song['id'], newBasePath, "album")
 
         print(
             f"Finished downloading {album['artists']} - {album['name']} album")


### PR DESCRIPTION
If an album has multiple disks, each song was placed in a new folder <DISK_NUMBER> within the previous folder e.g. /01/01/01/01/4.title.mp3.
 Fixed