### PR TITLE
Prevent sanitization applying to track metadata (ID3 tags)

### DIFF
--- a/zspotify/zspotify_api.py
+++ b/zspotify/zspotify_api.py
@@ -267,10 +267,10 @@ class ZSpotifyApi:
             artist_id = info['tracks'][0]['artists'][0]['id']
             artists = []
             for data in info["tracks"][0]["artists"]:
-                artists.append(self.sanitize_data(data["name"]))
+                artists.append(data["name"])
             artist_name = artists
-            album_name = self.sanitize_data(info["tracks"][0]["album"]["name"])
-            song_name = self.sanitize_data(info["tracks"][0]["name"])
+            album_name = info["tracks"][0]["album"]["name"]
+            song_name = info["tracks"][0]["name"]
             image_url = info["tracks"][0]["album"]["images"][img_index]["url"] if img_index >= 0 else None
             release_year = info["tracks"][0]["album"]["release_date"].split("-")[0]
             disc_number = info["tracks"][0]["disc_number"]


### PR DESCRIPTION
This PR addresses issue #97, by curtailing sanitization to apply to filenames only, and not to apply to track metadata (ID3 tags), so that metadata is not spoiled (otherwise it gets stripped of apostrophes, colons, etc).

Tested via a playlist download (successful), but not tested other use cases