### PR TITLE
Python version to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine as builder
+FROM python:3.10-alpine as builder
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN mkdir -p /app/ffmpeg-deps \
     | grep -v 'ld-musl-x86_64.so.1' \
     | xargs -I '{}' cp -v '{}' .
 
-FROM python:3.9-alpine
+FROM python:3.10-alpine
 
 # Copy over ffmpeg and its dependencies
 COPY --from=builder /usr/bin/ffmpeg /usr/bin/ffmpeg


### PR DESCRIPTION
Tried building with 3.9 which results in an error on __main__.py line 465, invalid syntax at the match statement (only valid >=3.10)